### PR TITLE
Update ResourceConverterExtenstions.cs

### DIFF
--- a/Src/HoneyBear.HalClient.Unit.Tests/HalClientTestContext.cs
+++ b/Src/HoneyBear.HalClient.Unit.Tests/HalClientTestContext.cs
@@ -361,6 +361,7 @@ namespace HoneyBear.HalClient.Unit.Tests
                 _order.OrderRef,
                 _order.OrderNumber,
                 _order.Status,
+                _order.DeliveryDate,
                 _order.Total,
                 _links =
                     new
@@ -400,6 +401,7 @@ namespace HoneyBear.HalClient.Unit.Tests
                 _order.OrderRef,
                 _order.OrderNumber,
                 _order.Status,
+                _order.DeliveryDate,
                 _order.Total,
                 _links =
                     new
@@ -492,6 +494,7 @@ namespace HoneyBear.HalClient.Unit.Tests
                                     _order.OrderRef,
                                     _order.OrderNumber,
                                     _order.Status,
+                                    _order.DeliveryDate,
                                     _order.Total,
                                     _links =
                                         new
@@ -533,6 +536,7 @@ namespace HoneyBear.HalClient.Unit.Tests
                                     _order.OrderRef,
                                     _order.OrderNumber,
                                     _order.Status,
+                                    _order.DeliveryDate,
                                     _order.Total,
                                     _links =
                                         new
@@ -607,6 +611,7 @@ namespace HoneyBear.HalClient.Unit.Tests
                                     _order.OrderRef,
                                     _order.OrderNumber,
                                     _order.Status,
+                                    _order.DeliveryDate,
                                     _order.Total,
                                     _links =
                                         new

--- a/Src/HoneyBear.HalClient.Unit.Tests/HalClientTestContext.cs
+++ b/Src/HoneyBear.HalClient.Unit.Tests/HalClientTestContext.cs
@@ -47,7 +47,7 @@ namespace HoneyBear.HalClient.Unit.Tests
             _http = _fixture.Freeze<IJsonHttpClient>();
 
             _version = _fixture.Create<Version>();
-            _order = _fixture.Create<Order>();
+            _order = _fixture.Build<Order>().With(x => x.DeliveryDate, null).Create();
             _orderItem = _fixture.Create<OrderItem>();
             _paged = _fixture.Create<PagedList>();
             OrderAdd = _fixture.Create<OrderAdd>();

--- a/Src/HoneyBear.HalClient.Unit.Tests/ProxyResources/Order.cs
+++ b/Src/HoneyBear.HalClient.Unit.Tests/ProxyResources/Order.cs
@@ -8,6 +8,7 @@ namespace HoneyBear.HalClient.Unit.Tests.ProxyResources
         public Guid OrderRef { get; set; }
         public string OrderNumber { get; set; }
         public string Status { get; set; }
+        public DateTime? DeliveryDate { get; set; }
         public Money Total { get; set; }
     }
 }

--- a/Src/HoneyBear.HalClient/Models/ResourceConverterExtenstions.cs
+++ b/Src/HoneyBear.HalClient/Models/ResourceConverterExtenstions.cs
@@ -33,8 +33,10 @@ namespace HoneyBear.HalClient.Models
                     value = complex.ToObject(propertyType);
                 else if (array != null)
                     value = array.ToObject(propertyType);
-                else
+                else if (pair.Value != null)
                     value = TypeDescriptor.GetConverter(propertyType).ConvertFromInvariantString(pair.Value.ToString());
+                else
+                    value = null;
 
                 property.SetValue(data, value, null);
             }


### PR DESCRIPTION
These lines will allow to deserialize a nullable property if the API return null as value.