### PR TITLE
Make HalClient immutable

### DIFF
--- a/Src/HoneyBear.HalClient.Unit.Tests/App.config
+++ b/Src/HoneyBear.HalClient.Unit.Tests/App.config
@@ -17,8 +17,8 @@
         <assemblyIdentity name="Ploeh.SemanticComparison"
                           publicKeyToken="b24654c590009d4f"
                           culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.50.0.0"
-                         newVersion="3.50.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-3.51.0.0"
+                         newVersion="3.51.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Src/HoneyBear.HalClient.Unit.Tests/HalClientTestContext.cs
+++ b/Src/HoneyBear.HalClient.Unit.Tests/HalClientTestContext.cs
@@ -20,7 +20,7 @@ using Version = HoneyBear.HalClient.Unit.Tests.ProxyResources.Version;
 
 namespace HoneyBear.HalClient.Unit.Tests
 {
-    internal class HalClientTestContext
+    internal sealed class HalClientTestContext
     {
         public const string RootUri = "/v1/version/1";
         public const string Curie = "retail";
@@ -263,22 +263,22 @@ namespace HoneyBear.HalClient.Unit.Tests
 
         public void AssertThatResourceHasRelationship()
         {
-            _sut.Has("order-edit", Curie).Should().BeTrue("Resource should have relationship");
+            _result.Has("order-edit", Curie).Should().BeTrue("Resource should have relationship");
         }
 
         public void AssertThatResourceHasRelationshipWithoutCurie()
         {
-            _sut.Has("order-edit").Should().BeTrue("Resource should have relationship");
+            _result.Has("order-edit").Should().BeTrue("Resource should have relationship");
         }
 
         public void AssertThatResourceDoesNotHasRelationship()
         {
-            _sut.Has("whatever", Curie).Should().BeFalse("Resource should not have relationship");
+            _result.Has("whatever", Curie).Should().BeFalse("Resource should not have relationship");
         }
 
         public void AssertThatResourceDoesNotHasRelationshipWithoutCurie()
         {
-            _sut.Has("whatever").Should().BeFalse("Resource should not have relationship");
+            _result.Has("whatever").Should().BeFalse("Resource should not have relationship");
         }
 
         public void AssertThatHttpClientCanBeProvided()

--- a/Src/HoneyBear.HalClient.Unit.Tests/HalClientUnitTests.cs
+++ b/Src/HoneyBear.HalClient.Unit.Tests/HalClientUnitTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using HoneyBear.HalClient.Models;
 using HoneyBear.HalClient.Unit.Tests.ProxyResources;
 using NUnit.Framework;
@@ -7,8 +6,9 @@ using NUnit.Framework;
 namespace HoneyBear.HalClient.Unit.Tests
 {
     [TestFixture]
-    internal class HalClientUnitTests
+    internal sealed class HalClientUnitTests
     {
+        private const string Curie = HalClientTestContext.Curie;
         private HalClientTestContext _context;
 
         [SetUp]
@@ -34,11 +34,11 @@ namespace HoneyBear.HalClient.Unit.Tests
                 .ArrangeHomeResource()
                 .ArrangeSingleResource();
 
-            Func<IHalClient, IHalClient> act = sut =>
-                sut
-                    .Root(HalClientTestContext.RootUri)
-                    .Get("order", new {orderRef = _context.OrderRef}, HalClientTestContext.Curie);
-            _context.Act(act);
+            IHalClient Act(IHalClient sut) => sut
+                .Root(HalClientTestContext.RootUri)
+                .Get("order", new {orderRef = _context.OrderRef}, Curie);
+
+            _context.Act(Act);
 
             _context.AssertThatSingleResourceIsPresent();
         }
@@ -50,12 +50,12 @@ namespace HoneyBear.HalClient.Unit.Tests
                 .ArrangeHomeResource()
                 .ArrangeSingleResource();
 
-            Func<IHalClient, IHalClient> act = sut =>
-                sut
-                    .Root(HalClientTestContext.RootUri)
-                    .Get("order", new {orderRef = _context.OrderRef}, HalClientTestContext.Curie)
-                    .Get("orderitem", HalClientTestContext.Curie);
-            _context.Act(act);
+            IHalClient Act(IHalClient sut) => sut
+                .Root(HalClientTestContext.RootUri)
+                .Get("order", new {orderRef = _context.OrderRef}, Curie)
+                .Get("orderitem", Curie);
+
+            _context.Act(Act);
 
             _context.AssertThatSingleEmbeddedResourceIsPresent();
         }
@@ -67,11 +67,11 @@ namespace HoneyBear.HalClient.Unit.Tests
                 .ArrangeHomeResource()
                 .ArrangePagedResource();
 
-            Func<IHalClient, IHalClient> act = sut =>
-                sut
-                    .Root(HalClientTestContext.RootUri)
-                    .Get("order-queryby-user", new {userRef = HalClientTestContext.UserRef}, HalClientTestContext.Curie);
-            _context.Act(act);
+            IHalClient Act(IHalClient sut) => sut
+                .Root(HalClientTestContext.RootUri)
+                .Get("order-queryby-user", new {userRef = HalClientTestContext.UserRef}, Curie);
+
+            _context.Act(Act);
 
             _context.AssertThatPagedResourceIsPresent();
         }
@@ -83,12 +83,12 @@ namespace HoneyBear.HalClient.Unit.Tests
                 .ArrangeHomeResource()
                 .ArrangePagedResource();
 
-            Func<IHalClient, IHalClient> act = sut =>
-                sut
-                    .Root(HalClientTestContext.RootUri)
-                    .Get("order-queryby-user", new {userRef = HalClientTestContext.UserRef}, HalClientTestContext.Curie)
-                    .Get("order", HalClientTestContext.Curie);
-            _context.Act(act);
+            IHalClient Act(IHalClient sut) => sut
+                .Root(HalClientTestContext.RootUri)
+                .Get("order-queryby-user", new {userRef = HalClientTestContext.UserRef}, Curie)
+                .Get("order", Curie);
+
+            _context.Act(Act);
 
             _context.AssertThatEmbeddedPagedResourceIsPresent();
         }
@@ -100,24 +100,23 @@ namespace HoneyBear.HalClient.Unit.Tests
                 .ArrangeHomeResource()
                 .ArrangePagedResourceWithEmbeddedArrayOfResources();
 
-            Func<IHalClient, IHalClient> act =
-                sut =>
-                {
-                    var order =
-                        sut
-                            .Root(HalClientTestContext.RootUri)
-                            .Get("order-queryby-user", new {userRef = HalClientTestContext.UserRef}, HalClientTestContext.Curie)
-                            .Get("order", HalClientTestContext.Curie)
-                            .Items<Order>()
-                            .First();
-
+            IHalClient Act(IHalClient sut)
+            {
+                var order =
                     sut
-                        .Get(order, "orderitem-query", HalClientTestContext.Curie)
-                        .Get("orderitem", HalClientTestContext.Curie);
+                        .Root(HalClientTestContext.RootUri)
+                        .Get("order-queryby-user", new {userRef = HalClientTestContext.UserRef}, Curie)
+                        .Get("order", Curie)
+                        .Items<Order>()
+                        .First();
 
-                    return sut;
-                };
-            _context.Act(act);
+                return
+                    sut
+                        .Get(order, "orderitem-query", Curie)
+                        .Get("orderitem", Curie);
+            }
+
+            _context.Act(Act);
 
             _context.AssertThatResourceArrayIsPresent();
         }
@@ -129,24 +128,23 @@ namespace HoneyBear.HalClient.Unit.Tests
                 .ArrangeHomeResource()
                 .ArrangePagedResourceWithLinkedArrayOfResources();
 
-            Func<IHalClient, IHalClient> act =
-                sut =>
-                {
-                    var order =
-                        sut
-                            .Root(HalClientTestContext.RootUri)
-                            .Get("order-queryby-user", new {userRef = HalClientTestContext.UserRef}, HalClientTestContext.Curie)
-                            .Get("order", HalClientTestContext.Curie)
-                            .Items<Order>()
-                            .First();
-
+            IHalClient Act(IHalClient sut)
+            {
+                var order =
                     sut
-                        .Get(order, "orderitem-query", HalClientTestContext.Curie)
-                        .Get("orderitem", HalClientTestContext.Curie);
+                        .Root(HalClientTestContext.RootUri)
+                        .Get("order-queryby-user", new {userRef = HalClientTestContext.UserRef}, Curie)
+                        .Get("order", Curie)
+                        .Items<Order>()
+                        .First();
 
-                    return sut;
-                };
-            _context.Act(act);
+                return
+                    sut
+                        .Get(order, "orderitem-query", Curie)
+                        .Get("orderitem", Curie);
+            }
+
+            _context.Act(Act);
 
             _context.AssertThatResourceArrayIsPresent();
         }
@@ -158,11 +156,11 @@ namespace HoneyBear.HalClient.Unit.Tests
                 .ArrangeHomeResource()
                 .ArrangeResourceWithJsonAttribute();
 
-            Func<IHalClient, IHalClient> act = sut =>
-                sut
-                    .Root(HalClientTestContext.RootUri)
-                    .Get("resource-with-json-attribute", null, HalClientTestContext.Curie);
-            _context.Act(act);
+            IHalClient Act(IHalClient sut) => sut
+                .Root(HalClientTestContext.RootUri)
+                .Get("resource-with-json-attribute", null, Curie);
+
+            _context.Act(Act);
 
             _context.AssertThatResourceWithJsonAttributeIsPresent();
         }
@@ -175,11 +173,11 @@ namespace HoneyBear.HalClient.Unit.Tests
                 .ArrangeSingleResource()
                 .ArrangeCreatedResource();
 
-            Func<IHalClient, IHalClient> act = sut =>
-                sut
-                    .Root(HalClientTestContext.RootUri)
-                    .Post("order-add", _context.OrderAdd, HalClientTestContext.Curie);
-            _context.Act(act);
+            IHalClient Act(IHalClient sut) => sut
+                .Root(HalClientTestContext.RootUri)
+                .Post("order-add", _context.OrderAdd, Curie);
+
+            _context.Act(Act);
 
             _context.AssertThatResourceWasCreated();
         }
@@ -192,11 +190,11 @@ namespace HoneyBear.HalClient.Unit.Tests
                 .ArrangeSingleResource()
                 .ArrangeCreatedResource();
 
-            Func<IHalClient, IHalClient> act = sut =>
-                sut
-                    .Root(HalClientTestContext.RootUri)
-                    .Post("order-add", _context.OrderAdd, new {orderRef = _context.OrderRef}, HalClientTestContext.Curie);
-            _context.Act(act);
+            IHalClient Act(IHalClient sut) => sut
+                .Root(HalClientTestContext.RootUri)
+                .Post("order-add", _context.OrderAdd, new {orderRef = _context.OrderRef}, Curie);
+
+            _context.Act(Act);
 
             _context.AssertThatResourceWasCreated();
         }
@@ -210,11 +208,11 @@ namespace HoneyBear.HalClient.Unit.Tests
                 .ArrangeSingleResource()
                 .ArrangeCreatedResource();
 
-            Func<IHalClient, IHalClient> act = sut =>
-                sut
-                    .Root(HalClientTestContext.RootUri)
-                    .Post("order-add", _context.OrderAdd);
-            _context.Act(act);
+            IHalClient Act(IHalClient sut) => sut
+                .Root(HalClientTestContext.RootUri)
+                .Post("order-add", _context.OrderAdd);
+
+            _context.Act(Act);
 
             _context.AssertThatResourceWasCreated();
         }
@@ -227,11 +225,11 @@ namespace HoneyBear.HalClient.Unit.Tests
                 .ArrangeHomeResource()
                 .ArrangeCreatedResource();
 
-            Func<IHalClient, IHalClient> act = sut =>
-                sut
-                    .Root(HalClientTestContext.RootUri)
-                    .Post("order-add", _context.OrderAdd, new {orderRef = _context.OrderRef});
-            _context.Act(act);
+            IHalClient Act(IHalClient sut) => sut
+                .Root(HalClientTestContext.RootUri)
+                .Post("order-add", _context.OrderAdd, new {orderRef = _context.OrderRef});
+
+            _context.Act(Act);
 
             _context.AssertThatResourceWasCreated();
         }
@@ -244,12 +242,12 @@ namespace HoneyBear.HalClient.Unit.Tests
                 .ArrangeSingleResource()
                 .ArrangeUpdatedResource();
 
-            Func<IHalClient, IHalClient> act = sut =>
-                sut
-                    .Root(HalClientTestContext.RootUri)
-                    .Get("order", new {orderRef = _context.OrderRef}, HalClientTestContext.Curie)
-                    .Put("order-edit", _context.OrderEdit, HalClientTestContext.Curie);
-            _context.Act(act);
+            IHalClient Act(IHalClient sut) => sut
+                .Root(HalClientTestContext.RootUri)
+                .Get("order", new {orderRef = _context.OrderRef}, Curie)
+                .Put("order-edit", _context.OrderEdit, Curie);
+
+            _context.Act(Act);
 
             _context.AssertThatResourceWasUpdated();
         }
@@ -262,14 +260,11 @@ namespace HoneyBear.HalClient.Unit.Tests
                 .ArrangeSingleResource()
                 .ArrangeUpdatedResource();
 
-            Func<IHalClient, IHalClient> act = sut =>
-            {
-                var parameters = new {orderRef = _context.OrderRef};
-                return sut
-                    .Root(HalClientTestContext.RootUri)
-                    .Put("order-edit", _context.OrderEdit, parameters, HalClientTestContext.Curie);
-            };
-            _context.Act(act);
+            IHalClient Act(IHalClient sut) => sut
+                .Root(HalClientTestContext.RootUri)
+                .Put("order-edit", _context.OrderEdit, new {orderRef = _context.OrderRef}, Curie);
+
+            _context.Act(Act);
 
             _context.AssertThatResourceWasUpdated();
         }
@@ -283,12 +278,12 @@ namespace HoneyBear.HalClient.Unit.Tests
                 .ArrangeSingleResource()
                 .ArrangeUpdatedResource();
 
-            Func<IHalClient, IHalClient> act = sut =>
-                sut
-                    .Root(HalClientTestContext.RootUri)
-                    .Get("order", new {orderRef = _context.OrderRef})
-                    .Put("order-edit", _context.OrderEdit);
-            _context.Act(act);
+            IHalClient Act(IHalClient sut) => sut
+                .Root(HalClientTestContext.RootUri)
+                .Get("order", new {orderRef = _context.OrderRef})
+                .Put("order-edit", _context.OrderEdit);
+
+            _context.Act(Act);
 
             _context.AssertThatResourceWasUpdated();
         }
@@ -301,11 +296,11 @@ namespace HoneyBear.HalClient.Unit.Tests
                 .ArrangeHomeResource()
                 .ArrangeUpdatedResource();
 
-            Func<IHalClient, IHalClient> act = sut =>
-                sut
-                    .Root(HalClientTestContext.RootUri)
-                    .Put("order-edit", _context.OrderEdit, new {orderRef = _context.OrderRef});
-            _context.Act(act);
+            IHalClient Act(IHalClient sut) => sut
+                .Root(HalClientTestContext.RootUri)
+                .Put("order-edit", _context.OrderEdit, new {orderRef = _context.OrderRef});
+
+            _context.Act(Act);
 
             _context.AssertThatResourceWasUpdated();
         }
@@ -318,12 +313,12 @@ namespace HoneyBear.HalClient.Unit.Tests
                 .ArrangeSingleResource()
                 .ArrangePatchedResource();
 
-            Func<IHalClient, IHalClient> act = sut =>
-                sut
-                    .Root(HalClientTestContext.RootUri)
-                    .Get("order", new { orderRef = _context.OrderRef }, HalClientTestContext.Curie)
-                    .Patch("order-edit", _context.OrderEdit, HalClientTestContext.Curie);
-            _context.Act(act);
+            IHalClient Act(IHalClient sut) => sut
+                .Root(HalClientTestContext.RootUri)
+                .Get("order", new {orderRef = _context.OrderRef}, Curie)
+                .Patch("order-edit", _context.OrderEdit, Curie);
+
+            _context.Act(Act);
 
             //For simplicty we don't actually apply any patch here, 
             //but just test if the payload arrived via PATCH
@@ -338,14 +333,11 @@ namespace HoneyBear.HalClient.Unit.Tests
                 .ArrangeSingleResource()
                 .ArrangePatchedResource();
 
-            Func<IHalClient, IHalClient> act = sut =>
-            {
-                var parameters = new { orderRef = _context.OrderRef };
-                return sut
-                    .Root(HalClientTestContext.RootUri)
-                    .Patch("order-edit", _context.OrderEdit, parameters, HalClientTestContext.Curie);
-            };
-            _context.Act(act);
+            IHalClient Act(IHalClient sut) => sut
+                .Root(HalClientTestContext.RootUri)
+                .Patch("order-edit", _context.OrderEdit, new {orderRef = _context.OrderRef}, Curie);
+
+            _context.Act(Act);
             
             //For simplicty we don't actually apply any patch here, 
             //but just test if the payload arrived via PATCH
@@ -361,12 +353,12 @@ namespace HoneyBear.HalClient.Unit.Tests
                 .ArrangeSingleResource()
                 .ArrangePatchedResource();
 
-            Func<IHalClient, IHalClient> act = sut =>
-                sut
-                    .Root(HalClientTestContext.RootUri)
-                    .Get("order", new { orderRef = _context.OrderRef })
-                    .Patch("order-edit", _context.OrderEdit);
-            _context.Act(act);
+            IHalClient Act(IHalClient sut) => sut
+                .Root(HalClientTestContext.RootUri)
+                .Get("order", new {orderRef = _context.OrderRef})
+                .Patch("order-edit", _context.OrderEdit);
+
+            _context.Act(Act);
 
             //For simplicty we don't actually apply any patch here, 
             //but just test if the payload arrived via PATCH
@@ -381,11 +373,11 @@ namespace HoneyBear.HalClient.Unit.Tests
                 .ArrangeHomeResource()
                 .ArrangePatchedResource();
 
-            Func<IHalClient, IHalClient> act = sut =>
-                sut
-                    .Root(HalClientTestContext.RootUri)
-                    .Patch("order-edit", _context.OrderEdit, new { orderRef = _context.OrderRef });
-            _context.Act(act);
+            IHalClient Act(IHalClient sut) => sut
+                .Root(HalClientTestContext.RootUri)
+                .Patch("order-edit", _context.OrderEdit, new {orderRef = _context.OrderRef});
+
+            _context.Act(Act);
 
             //For simplicty we don't actually apply any patch here, 
             //but just test if the payload arrived via PATCH
@@ -400,12 +392,12 @@ namespace HoneyBear.HalClient.Unit.Tests
                 .ArrangeSingleResource()
                 .ArrangeDeletedResource();
 
-            Func<IHalClient, IHalClient> act = sut =>
-                sut
-                    .Root(HalClientTestContext.RootUri)
-                    .Get("order", new {orderRef = _context.OrderRef}, HalClientTestContext.Curie)
-                    .Delete("order-delete", HalClientTestContext.Curie);
-            _context.Act(act);
+            IHalClient Act(IHalClient sut) => sut
+                .Root(HalClientTestContext.RootUri)
+                .Get("order", new {orderRef = _context.OrderRef}, Curie)
+                .Delete("order-delete", Curie);
+
+            _context.Act(Act);
 
             _context.AssertThatResourceWasDeleted();
         }
@@ -417,11 +409,11 @@ namespace HoneyBear.HalClient.Unit.Tests
                 .ArrangeHomeResource()
                 .ArrangeDeletedResource();
 
-            Func<IHalClient, IHalClient> act = sut =>
-                sut
-                    .Root(HalClientTestContext.RootUri)
-                    .Delete("order-delete", new {orderRef = _context.OrderRef}, HalClientTestContext.Curie);
-            _context.Act(act);
+            IHalClient Act(IHalClient sut) => sut
+                .Root(HalClientTestContext.RootUri)
+                .Delete("order-delete", new {orderRef = _context.OrderRef}, Curie);
+
+            _context.Act(Act);
 
             _context.AssertThatResourceWasDeleted();
         }
@@ -435,12 +427,12 @@ namespace HoneyBear.HalClient.Unit.Tests
                 .ArrangeSingleResource()
                 .ArrangeDeletedResource();
 
-            Func<IHalClient, IHalClient> act = sut =>
-                sut
-                    .Root(HalClientTestContext.RootUri)
-                    .Get("order", new {orderRef = _context.OrderRef})
-                    .Delete("order-delete");
-            _context.Act(act);
+            IHalClient Act(IHalClient sut) => sut
+                .Root(HalClientTestContext.RootUri)
+                .Get("order", new {orderRef = _context.OrderRef})
+                .Delete("order-delete");
+
+            _context.Act(Act);
 
             _context.AssertThatResourceWasDeleted();
         }
@@ -453,11 +445,11 @@ namespace HoneyBear.HalClient.Unit.Tests
                 .ArrangeHomeResource()
                 .ArrangeDeletedResource();
 
-            Func<IHalClient, IHalClient> act = sut =>
-                sut
-                    .Root(HalClientTestContext.RootUri)
-                    .Delete("order-delete", new {orderRef = _context.OrderRef});
-            _context.Act(act);
+            IHalClient Act(IHalClient sut) => sut
+                .Root(HalClientTestContext.RootUri)
+                .Delete("order-delete", new {orderRef = _context.OrderRef});
+
+            _context.Act(Act);
 
             _context.AssertThatResourceWasDeleted();
         }
@@ -469,11 +461,11 @@ namespace HoneyBear.HalClient.Unit.Tests
                 .ArrangeHomeResource()
                 .ArrangeSingleResource();
 
-            Func<IHalClient, IHalClient> act = sut =>
-                sut
-                    .Root(HalClientTestContext.RootUri)
-                    .Get("order", new {orderRef = _context.OrderRef}, HalClientTestContext.Curie);
-            _context.Act(act);
+            IHalClient Act(IHalClient sut) => sut
+                .Root(HalClientTestContext.RootUri)
+                .Get("order", new {orderRef = _context.OrderRef}, Curie);
+
+            _context.Act(Act);
 
             _context.AssertThatResourceHasRelationship();
         }
@@ -486,11 +478,11 @@ namespace HoneyBear.HalClient.Unit.Tests
                 .ArrangeHomeResource()
                 .ArrangeSingleResource();
 
-            Func<IHalClient, IHalClient> act = sut =>
-                sut
-                    .Root(HalClientTestContext.RootUri)
-                    .Get("order", new {orderRef = _context.OrderRef});
-            _context.Act(act);
+            IHalClient Act(IHalClient sut) => sut
+                .Root(HalClientTestContext.RootUri)
+                .Get("order", new {orderRef = _context.OrderRef});
+
+            _context.Act(Act);
 
             _context.AssertThatResourceHasRelationshipWithoutCurie();
         }
@@ -502,11 +494,11 @@ namespace HoneyBear.HalClient.Unit.Tests
                 .ArrangeHomeResource()
                 .ArrangeSingleResource();
 
-            Func<IHalClient, IHalClient> act = sut =>
-                sut
-                    .Root(HalClientTestContext.RootUri)
-                    .Get("order", new {orderRef = _context.OrderRef}, HalClientTestContext.Curie);
-            _context.Act(act);
+            IHalClient Act(IHalClient sut) => sut
+                .Root(HalClientTestContext.RootUri)
+                .Get("order", new {orderRef = _context.OrderRef}, Curie);
+
+            _context.Act(Act);
 
             _context.AssertThatResourceDoesNotHasRelationship();
         }
@@ -519,11 +511,11 @@ namespace HoneyBear.HalClient.Unit.Tests
                 .ArrangeHomeResource()
                 .ArrangeSingleResource();
 
-            Func<IHalClient, IHalClient> act = sut =>
-                sut
-                    .Root(HalClientTestContext.RootUri)
-                    .Get("order", new {orderRef = _context.OrderRef});
-            _context.Act(act);
+            IHalClient Act(IHalClient sut) => sut
+                .Root(HalClientTestContext.RootUri)
+                .Get("order", new {orderRef = _context.OrderRef});
+
+            _context.Act(Act);
 
             _context.AssertThatResourceDoesNotHasRelationshipWithoutCurie();
         }
@@ -536,11 +528,11 @@ namespace HoneyBear.HalClient.Unit.Tests
                 .ArrangeHomeResource()
                 .ArrangeSingleResource();
 
-            Func<IHalClient, IHalClient> act = sut =>
-                sut
-                    .Root(HalClientTestContext.RootUri)
-                    .Get("order", new {orderRef = _context.OrderRef});
-            _context.Act(act);
+            IHalClient Act(IHalClient sut) => sut
+                .Root(HalClientTestContext.RootUri)
+                .Get("order", new {orderRef = _context.OrderRef});
+
+            _context.Act(Act);
 
             _context.AssertThatSingleResourceIsPresent();
         }
@@ -553,11 +545,11 @@ namespace HoneyBear.HalClient.Unit.Tests
                 .ArrangeHomeResource()
                 .ArrangeDefaultPagedResource();
 
-            Func<IHalClient, IHalClient> act = sut =>
-                sut
-                    .Root(HalClientTestContext.RootUri)
-                    .Get("order-query-all");
-            _context.Act(act);
+            IHalClient Act(IHalClient sut) => sut
+                .Root(HalClientTestContext.RootUri)
+                .Get("order-query-all");
+
+            _context.Act(Act);
 
             _context.AssertThatPagedResourceIsPresent();
         }
@@ -581,11 +573,11 @@ namespace HoneyBear.HalClient.Unit.Tests
                 .ArrangeDefaultHomeResource()
                 .ArrangeSingleResource();
 
-            Func<IHalClient, IHalClient> act = sut =>
-                sut
-                    .Root()
-                    .Get("order", new {orderRef = _context.OrderRef}, HalClientTestContext.Curie);
-            _context.Act(act);
+            IHalClient Act(IHalClient sut) => sut
+                .Root()
+                .Get("order", new {orderRef = _context.OrderRef}, Curie);
+
+            _context.Act(Act);
 
             _context.AssertThatSingleResourceIsPresent();
         }
@@ -597,12 +589,11 @@ namespace HoneyBear.HalClient.Unit.Tests
                 .ArrangeHomeResource()
                 .ArrangeSingleResource();
 
-            Func<IHalClient, IHalClient> act = sut =>
-                sut
-                    .Root(HalClientTestContext.RootUri)
-                    .Get("order", HalClientTestContext.Curie);
+            IHalClient Act(IHalClient sut) => sut
+                .Root(HalClientTestContext.RootUri)
+                .Get("order", Curie);
 
-            Assert.Throws<TemplateParametersAreRequired>(() => _context.Act(act));
+            Assert.Throws<TemplateParametersAreRequired>(() => _context.Act(Act));
         }
 
         [Test]
@@ -612,12 +603,11 @@ namespace HoneyBear.HalClient.Unit.Tests
                 .ArrangeHomeResource()
                 .ArrangeSingleResource();
 
-            Func<IHalClient, IHalClient> act = sut =>
-                sut
-                    .Root(HalClientTestContext.RootUri)
-                    .Get("I-do-not-exist", HalClientTestContext.Curie);
+            IHalClient Act(IHalClient sut) => sut
+                .Root(HalClientTestContext.RootUri)
+                .Get("I-do-not-exist", Curie);
 
-            Assert.Throws<FailedToResolveRelationship>(() => _context.Act(act));
+            Assert.Throws<FailedToResolveRelationship>(() => _context.Act(Act));
         }
 
         [Test]
@@ -631,10 +621,9 @@ namespace HoneyBear.HalClient.Unit.Tests
         {
             _context.ArrangeFailedHomeRequest();
 
-            Func<IHalClient, IHalClient> act = sut =>
-                sut.Root(HalClientTestContext.RootUri);
+            IHalClient Act(IHalClient sut) => sut.Root(HalClientTestContext.RootUri);
 
-            Assert.Throws<HttpRequestFailed>(() => _context.Act(act));
+            Assert.Throws<HttpRequestFailed>(() => _context.Act(Act));
         }
     }
 }

--- a/Src/HoneyBear.HalClient.Unit.Tests/HoneyBear.HalClient.Unit.Tests.csproj
+++ b/Src/HoneyBear.HalClient.Unit.Tests/HoneyBear.HalClient.Unit.Tests.csproj
@@ -5,17 +5,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture" Version="3.50.6" />
-    <PackageReference Include="AutoFixture.AutoRhinoMocks" Version="3.50.6" />
-    <PackageReference Include="coveralls.io" Version="1.3.4" />
+    <PackageReference Include="AutoFixture" Version="3.51.0" />
+    <PackageReference Include="AutoFixture.AutoRhinoMocks" Version="3.51.0" />
+    <PackageReference Include="coveralls.io" Version="1.4.2" />
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="NMoneys" Version="5.1.4.1" />
     <PackageReference Include="NUnit" Version="3.8.1" />
     <PackageReference Include="NUnit.ConsoleRunner" Version="3.7.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
     <PackageReference Include="OpenCover" Version="4.6.519" />
-    <PackageReference Include="SemanticComparison" Version="3.50.6" />
+    <PackageReference Include="SemanticComparison" Version="3.51.0" />
     <PackageReference Include="SemanticComparisonExtensions" Version="0.2.0" />
   </ItemGroup>
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,11 +35,11 @@ after_test:
     . $env:USERPROFILE\.nuget\packages\OpenCover\4.6.519\tools\OpenCover.Console.exe `
         -register:user `
         -filter:"+[HoneyBear.HalClient]*" `
-        -target:"$env:USERPROFILE\.nuget\packages\NUnit.ConsoleRunner\3.6.1\tools\nunit3-console.exe" `
+        -target:"$env:USERPROFILE\.nuget\packages\NUnit.ConsoleRunner\3.7.0\tools\nunit3-console.exe" `
         -targetargs:".\Src\HoneyBear.HalClient.Unit.Tests\bin\$env:CONFIGURATION\net452\HoneyBear.HalClient.Unit.Tests.dll" `
         -output:coverage.xml
 
-    . $env:USERPROFILE\.nuget\packages\coveralls.io\1.3.4\tools\coveralls.net.exe `
+    . $env:USERPROFILE\.nuget\packages\coveralls.io\1.4.2\tools\coveralls.net.exe `
         --opencover coverage.xml `
         --repo-token hOBugtrP7A2crVX8BA0cT9E8GjnlK8bcP
 deploy: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.3.{build}
+version: 2.0.{build}
 image: Visual Studio 2017
 skip_tags: true
 configuration: Release


### PR DESCRIPTION
In an effort to introduce async (see #18), it is necessary to make HalClient an immutable object.