### PR TITLE
[24] Retrieve embedded resources

### DIFF
--- a/Src/HoneyBear.HalClient/HoneyBear.HalClient.csproj
+++ b/Src/HoneyBear.HalClient/HoneyBear.HalClient.csproj
@@ -15,7 +15,7 @@
     <Description>A lightweight fluent .NET client for navigating and consuming HAL APIs.  Includes support for .NET Standard.</Description>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\HoneyBear.HalClient.xml</DocumentationFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageLicenseUrl>https://github.com/eoin55/HoneyBear.HalClient/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageLicense>https://github.com/eoin55/HoneyBear.HalClient/blob/master/LICENSE</PackageLicense>
     <PackageProjectUrl>https://github.com/eoin55/HoneyBear.HalClient</PackageProjectUrl>
     <PackageTags>HAL JSON Hypermedia HATEOAS REST DotNetCore NetStandard</PackageTags>
     <RepositoryUrl>https://github.com/eoin55/HoneyBear.HalClient</RepositoryUrl>

--- a/Src/HoneyBear.HalClient/Models/ResourceConverterExtensions.cs
+++ b/Src/HoneyBear.HalClient/Models/ResourceConverterExtensions.cs
@@ -11,7 +11,7 @@ namespace HoneyBear.HalClient.Models
     /// <summary>
     /// Contains a set of IResource extensions.
     /// </summary>
-    public static class ResourceConverterExtenstions
+    public static class ResourceConverterExtensions
     {
         internal static T Data<T>(this IResource source)
             where T : class, new()

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 2.2.{build}
+version: 2.3.{build}
 image: Visual Studio 2017
 skip_tags: true
 configuration: Release


### PR DESCRIPTION
Fixed an issue where the HalClient wasn't retrieving embedded resources.

Now it looks for embedded resources by matching on the self link.
If there are no matches, it follows the link (via a HTTP request).